### PR TITLE
Accessibility enhancements

### DIFF
--- a/components/layout/index.tsx
+++ b/components/layout/index.tsx
@@ -35,7 +35,7 @@ export default function Layout({
             target="_blank"
             rel="noopener noreferrer"
             // here we are using the `isolate` property to create a new stacking context: https://github.com/tailwindlabs/tailwindcss/discussions/5675#discussioncomment-1987063
-            className="relative isolate overflow-hidden rounded-full w-32 px-10 py-4 focus:outline-none focus:ring-0"
+            className="relative isolate overflow-hidden rounded-full w-32 px-10 py-4"
           >
             <span className="absolute inset-px z-10 grid place-items-center rounded-full bg-black bg-gradient-to-t from-neutral-800 text-neutral-400 text-sm">
               View the code

--- a/components/slack-button.tsx
+++ b/components/slack-button.tsx
@@ -38,6 +38,7 @@ export default function SlackButton({
         }}
         className="group-hover:hidden block"
         viewBox="0 0 122.8 122.8"
+        aria-hidden="true"
       >
         <path
           d="M25.8 77.6c0 7.1-5.8 12.9-12.9 12.9S0 84.7 0 77.6s5.8-12.9 12.9-12.9h12.9v12.9zm6.5 0c0-7.1 5.8-12.9 12.9-12.9s12.9 5.8 12.9 12.9v32.3c0 7.1-5.8 12.9-12.9 12.9s-12.9-5.8-12.9-12.9V77.6z"

--- a/components/video-modal.tsx
+++ b/components/video-modal.tsx
@@ -1,5 +1,7 @@
 import Modal from "./modal";
 import {
+  useRef,
+  useEffect,
   useState,
   Dispatch,
   SetStateAction,
@@ -14,14 +16,22 @@ const VideoModal = ({
   showVideoModal: boolean;
   setShowVideoModal: Dispatch<SetStateAction<boolean>>;
 }) => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  useEffect(() => {
+    if (showVideoModal) videoRef.current?.focus();
+  }, [showVideoModal]);
+
   return (
     <Modal showModal={showVideoModal} setShowModal={setShowVideoModal}>
       <video
+        ref={videoRef}
         className="w-11/12 max-w-screen-xl aspect-video overflow-hidden shadow-xl rounded-2xl object-fill"
         autoPlay
         controls
         src="/assets/demo.mp4"
         poster="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAABIpJREFUWEeNV4tynEYQ3F24L04sWYKzLSfKT/tYUv2YfSA5FakoDuqge3p6Hpf3P76cyX9nykkXOVV8zriOI/Ez/toD7Q6eiCfxma/wt7Ov9ayv2hfylQBf1YCTiPiYwTtt43USwiJwA8zxSXfNLnUCBNVjBJyi10OnXzxIRj1Cl/kcSnwWuV+Et+5/Pvl9fjzjXBqBZCIfCFwTd8aNINRVaJ/47jERGQSeHXhIo+hBAuApF8XoxI75lyFw57yce7Ii/s9IkMr+5euFgIBzLikVkyCZwVl84uQ/CcSBO2e1S00Vp3g2nDFc5/3ptRHIjjjAeQYZEKEKYSRCp0QwgIJENXhcB8FQXd4ShyEV+/M2ECiMHIA6Fp1DkW5eg3bgs4qAzlKF/z1nTm1Pp1LwfBcxgxQDl0UEeE1SiB6pcUSMPAB9rocJiASPRiKqSEo2M25fv52KUFIDsAB48RGE/B1mwsaboq5HqocIVBOrFxVk7osC28sP3hcBgJa0lJUEloFEgQL2AF4jsylyAR+pmkR1OkiAh3ypPiIFmBm8b3t94/0W/bISeFlBQJ+lSkmFKrj0+GJHTAIPEjkOE5lICNy5JgeVNghsP0/mtmRKH8DraiKhxAcCNl0AHiJQj0c6qIRSIRVmBcZU5G37Sx4okL6kBcDrmkBgpRKr7i9WQN1HLqfplPuDBB5SAJ9rTYcrQl6ACtHSeznmbf/bJgSIFCB4IwElBgJMgXpAJ/BIx8PRk4QI8KAKocDY7iMF+3tXYAF4ELilG9VYpAR90BvRaEBGDOCHwEXgoAJTCkKFoRrydn+nB2AyKbCm2y0UuInQhQA83HrAKP/jlwmEGU0gnanGpG3gnhLb/R9WAQlcol+DyH8q8DF6KCEPHCzDnoJehionVMFEAJEjBbdBBZsxUuBGFApIfkT8q6Wgl6MUqBpb3in61OWdDwosa0Lkt/XGM+QHKXmg9KWsNaFw/+iB3gtmD7gNRytG9e37+wk5wgPh/u4DkVAzUiNCK24KsAxtvGZCG9BlqJnQy1Av8WwRAXuA0fYSVBX8XwJjGUKBKMNhIo4GtAp5Rx9gJ1StTz2AZDwTpjKMPgCQAI5mhOh7J4xZ0PaAgQRx9086YSeBElQjwpDCLKB0MeU4gDCMogMCHJ5Q9EyTW3G4PqSPkZx3zwLmmB3PUVN6NSINpJwK9gKWr6ccZe5TUJEPw6jG5tS3IpZe80BK+f76JhPmIKBm1OZAG0baEycCaLNBwsCYBRzRzYAGb8uMx3r0ARJwI2rdMIbQtBOMD8acHwg0In0h0Wo2EpDzexqgwMsPVQEUYBoked8HtCFpRxyXUkxDdLlIg85z9J2A1rkLATSi+8v3eSHBTuBNCCS0nrkJMXeKSOYa1q8ou7acxm+Ftv15pxx6AO7ch50wFOBiEusYwWXCMI/biiZdjFwAt32wr+ZqwFJOKqCbKhBeiwDSolWcLTcUaB0QKfgNgWZElV2F8/17IfIf8IRuaWgE7m0lAwl6IGSfNmP9PogfNz0F8sGc+/htMP5Elw7cK4cfOf8CzsEZUbNybRAAAAAASUVORK5CYII="
+        tabIndex={showVideoModal ? 0 : -1}
+        aria-label="Slacker Introduction Video"
       />
     </Modal>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,13 +32,13 @@ export default function Home() {
       <div className="relative my-10">
         <button
           onClick={() => setShowVideoModal(true)}
-          className="group flex justify-center items-center absolute z-10 w-[350px] h-[350px] sm:w-[500px] sm:h-[500px] rounded-full hover:backdrop-blur-sm hover:bg-black/20 focus:outline-none focus:ring-0 transition-all overflow-hidden"
+          className="group flex justify-center items-center absolute z-10 w-[350px] h-[350px] sm:w-[500px] sm:h-[500px] rounded-full hover:backdrop-blur-sm hover:bg-black/20 transition-all overflow-hidden"
         >
           <div className="flex justify-center items-center w-14 h-14 rounded-full bg-white shadow-lg">
-            <Play size={20} fill="#27272A" />
+            <Play size={20} fill="#27272A" aria-hidden="true" />
           </div>
           <p className="font-mono text-white absolute -bottom-10 group-hover:bottom-5 transition-all ease-in-out duration-300">
-            1:03
+            <span className="sr-only">Play Video. Length of Video is</span> 1:03
           </p>
         </button>
         <video
@@ -47,6 +47,8 @@ export default function Home() {
           muted
           src="/assets/demo-preview.mp4"
           className="w-[350px] h-[350px] sm:w-[500px] sm:h-[500px] rounded-full object-cover"
+          tabIndex={-1}
+          aria-label="Looping video preview"
         />
       </div>
       <div className="flex flex-col text-center space-y-2">


### PR DESCRIPTION
- Re-instate default browser outline styles on focus of elements. Setting `outline: none` without alternative styling to visually indicate a focus state makes keyboard navigation cumbersome.
- set decorative SVG icons to `aria-hidden="true"`
- better focus management for video in modal when opened
- remove looping preview video from tab flow since it is not actionable
- add descriptive text to media
- add descriptive text to video modal trigger button